### PR TITLE
Prefers local installation to prevent using system's hlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ machine:
   - 4) Run the following Stack commands in your Hlint directory:
     - Initialise a Stack configuration with `stack init`
     - Build the project and dependencies with `stack install`
-    - Run the tests with `hlint test` (requires `~/.local/bin/` on `$PATH`)
+    - Run the tests with `stack exec -- hlint test`
 
 [Install stack]: https://docs.haskellstack.org/en/stable/install_and_upgrade/
 [Fork Hlint on Github]: https://github.com/ndmitchell/hlint#fork-destination-box


### PR DESCRIPTION
`stack install` puts the `hlint` binary to a local subdir somewhere similar to 

    .stack-work/install/x86_64-linux/nightly-2016-10-02/8.0.1/bin/hlint

We don't want to run a globally installed `hlint` by accident: `stack exec` is able to figures the paths out.

Note: I do have a globally installed `hlint` (debatable if that is a good idea :P) and almost ran into this.

cc @lwm 